### PR TITLE
Fix some simulation errors (when the competition cannot start).

### DIFF
--- a/tac/agents/v1/core.py
+++ b/tac/agents/v1/core.py
@@ -214,7 +214,7 @@ class NegotiationAgent(OEFAgent):
             self._on_start(response)
         elif isinstance(response, TransactionConfirmation) and origin == self.controller_pbk:
             self.on_transaction_confirmed(response)
-        elif isinstance(response, Cancelled) and origin == self.controller_pbk and self._game_phase == self.GAME_PHASES[2]:
+        elif isinstance(response, Cancelled) and origin == self.controller_pbk and (self._game_phase == self.GAME_PHASES[2] or self._game_phase == self.GAME_PHASES[1]):
             self._on_cancelled()
         elif isinstance(response, StateUpdate) and self._game_phase == self.GAME_PHASES[2]:
             self.on_state_update(response)

--- a/tac/platform/controller.py
+++ b/tac/platform/controller.py
@@ -638,7 +638,7 @@ class ControllerAgent(OEFAgent):
             self._is_running = False
             self.game_handler.notify_tac_cancelled()
             self._loop.call_soon_threadsafe(self.stop)
-            self.monitor.stop()
+            if self.monitor.is_running: self.monitor.stop()
             self._message_processing_task.join()
             self._message_processing_task = None
 


### PR DESCRIPTION
- Check if the monitor is running before stopping it. 
- Handle 'cancelled' event also in the 'game setup' phase.

Closes #114 