### PR TITLE
Moves search stats into mailbox, fixes #244

### DIFF
--- a/tac/agents/v1/base/actions.py
+++ b/tac/agents/v1/base/actions.py
@@ -105,7 +105,6 @@ class OEFActions(OEFSearchActionInterface):
         search_id = self.game_instance.search.get_next_id()
         self.game_instance.search.ids_for_tac.add(search_id)
         self.out_box.out_queue.put(OutContainer(query=query, search_id=search_id))
-        self.game_instance.stats_manager.search_start(search_id)
 
     def update_services(self) -> None:
         """
@@ -170,7 +169,6 @@ class OEFActions(OEFSearchActionInterface):
                 search_id = self.game_instance.search.get_next_id()
                 self.game_instance.search.ids_for_sellers.add(search_id)
                 self.out_box.out_queue.put(OutContainer(query=query, search_id=search_id))
-                self.game_instance.stats_manager.search_start(search_id)
         if self.game_instance.strategy.is_searching_for_buyers:
             query = self.game_instance.build_services_query(is_searching_for_sellers=False)
             if query is None:
@@ -181,7 +179,6 @@ class OEFActions(OEFSearchActionInterface):
                 search_id = self.game_instance.search.get_next_id()
                 self.game_instance.search.ids_for_buyers.add(search_id)
                 self.out_box.out_queue.put(OutContainer(query=query, search_id=search_id))
-                self.game_instance.stats_manager.search_start(search_id)
 
 
 class DialogueActions(DialogueActionInterface):

--- a/tac/agents/v1/base/game_instance.py
+++ b/tac/agents/v1/base/game_instance.py
@@ -28,6 +28,7 @@ from oef.messages import CFP_TYPES
 from oef.query import Query
 from oef.schema import Description
 
+from tac.agents.v1.mail import MailStats
 from tac.agents.v1.base.dialogues import Dialogues
 from tac.agents.v1.base.lock_manager import LockManager
 from tac.agents.v1.base.strategy import Strategy
@@ -77,6 +78,7 @@ class GameInstance:
 
     def __init__(self, agent_name: str,
                  strategy: Strategy,
+                 mail_stats: MailStats,
                  services_interval: int = 10,
                  pending_transaction_timeout: int = 10,
                  dashboard: Optional[AgentDashboard] = None) -> None:
@@ -85,6 +87,7 @@ class GameInstance:
 
         :param agent_name: the name of the agent.
         :param strategy: the strategy of the agent.
+        :param mail_starts: the mail stats of the mailbox.
         :param services_interval: the interval at which services are updated.
         :param pending_transaction_timeout: the timeout after which transactions are removed from the lock manager.
         :param dashboard: the agent dashboard.
@@ -116,7 +119,7 @@ class GameInstance:
         self.lock_manager = LockManager(agent_name, pending_transaction_timeout=pending_transaction_timeout)
         self.lock_manager.start()
 
-        self.stats_manager = StatsManager(dashboard)
+        self.stats_manager = StatsManager(mail_stats, dashboard)
 
         self.dashboard = dashboard
         if self.dashboard is not None:

--- a/tac/agents/v1/base/game_instance.py
+++ b/tac/agents/v1/base/game_instance.py
@@ -87,7 +87,7 @@ class GameInstance:
 
         :param agent_name: the name of the agent.
         :param strategy: the strategy of the agent.
-        :param mail_starts: the mail stats of the mailbox.
+        :param mail_stats: the mail stats of the mailbox.
         :param services_interval: the interval at which services are updated.
         :param pending_transaction_timeout: the timeout after which transactions are removed from the lock manager.
         :param dashboard: the agent dashboard.

--- a/tac/agents/v1/base/participant_agent.py
+++ b/tac/agents/v1/base/participant_agent.py
@@ -76,7 +76,7 @@ class ParticipantAgent(Agent):
         self.out_box = OutBox(self.mail_box)
 
         self._is_competing = False  # type: bool
-        self._game_instance = GameInstance(name, strategy, services_interval, pending_transaction_timeout, dashboard)  # type: Optional[GameInstance]
+        self._game_instance = GameInstance(name, strategy, self.mail_box.mail_stats, services_interval, pending_transaction_timeout, dashboard)  # type: Optional[GameInstance]
         self.max_reactions = max_reactions
 
         self.controller_handler = ControllerHandler(self.crypto, self.liveness, self.game_instance, self.out_box, self.name)

--- a/tac/agents/v1/base/reactions.py
+++ b/tac/agents/v1/base/reactions.py
@@ -221,7 +221,6 @@ class OEFReactions(OEFSearchReactionInterface):
         :return: None
         """
         search_id = search_result.msg_id
-        self.game_instance.stats_manager.search_end(search_id, len(search_result.agents))
         logger.debug("[{}]: on search result: {} {}".format(self.agent_name, search_id, search_result.agents))
         if search_id in self.game_instance.search.ids_for_tac:
             self._on_controller_search_result(search_result.agents)

--- a/tac/agents/v1/base/stats_manager.py
+++ b/tac/agents/v1/base/stats_manager.py
@@ -20,13 +20,14 @@
 
 """This module contains a class to handle statistics on the TAC."""
 
-import datetime
 import time
 from enum import Enum
 from threading import Thread
 from typing import Dict
 
 import numpy as np
+
+from tac.agents.v1.mail import MailStats
 
 
 class EndState(Enum):
@@ -41,10 +42,11 @@ class EndState(Enum):
 class StatsManager(object):
     """Class to handle statistics on the game."""
 
-    def __init__(self, dashboard, task_timeout: float = 2.0) -> None:
+    def __init__(self, mail_stats, dashboard, task_timeout: float = 2.0) -> None:
         """
         Initialize a StatsManager.
 
+        :param mail_stats: the mail stats of the mail box.
         :param dashboard: The dashboard.
         :param task_timeout: seconds to sleep for the task
 
@@ -55,9 +57,7 @@ class StatsManager(object):
         self._update_stats_task = None
         self._update_stats_task_timeout = task_timeout
 
-        self._search_start_time = {}  # type: Dict[int, datetime.datetime]
-        self._search_timedelta = {}  # type: Dict[int, datetime.timedelta]
-        self._search_result_counts = {}  # type: Dict[int, int]
+        self._mail_stats = mail_stats
 
         self._self_initiated_dialogue_stats = {EndState.SUCCESSFUL: 0,
                                                EndState.DECLINED_CFP: 0,
@@ -67,6 +67,11 @@ class StatsManager(object):
                                                 EndState.DECLINED_CFP: 0,
                                                 EndState.DECLINED_PROPOSE: 0,
                                                 EndState.DECLINED_ACCEPT: 0}  # type: Dict[EndState, int]
+
+    @property
+    def mail_stats(self) -> MailStats:
+        """Get the mail stats."""
+        return self._mail_stats
 
     @property
     def self_initiated_dialogue_stats(self) -> Dict[EndState, int]:
@@ -92,38 +97,13 @@ class StatsManager(object):
         else:
             self._other_initiated_dialogue_stats[end_state] += 1
 
-    def search_start(self, search_id: int) -> None:
-        """
-        Add a search id and start time.
-
-        :param search_id: the search id
-
-        :return: None
-        """
-        assert search_id not in self._search_start_time
-        self._search_start_time[search_id] = datetime.datetime.now()
-
-    def search_end(self, search_id: int, nb_search_results: int) -> None:
-        """
-        Add end time for a search id.
-
-        :param search_id: the search id
-        :param nb_search_results: the number of agents returned in the search result
-
-        :return: None
-        """
-        assert search_id in self._search_start_time
-        assert search_id not in self._search_timedelta
-        self._search_timedelta[search_id] = (datetime.datetime.now() - self._search_start_time[search_id]).total_seconds() * 1000
-        self._search_result_counts[search_id] = nb_search_results
-
     def avg_search_time(self) -> float:
         """
         Average the search timedeltas.
 
         :return: avg search time in seconds
         """
-        timedeltas = list(self._search_timedelta.values())
+        timedeltas = list(self.mail_stats._search_timedelta.values())
         if len(timedeltas) == 0:
             result = 0
         else:
@@ -136,7 +116,7 @@ class StatsManager(object):
 
         :return: avg search result counts
         """
-        counts = list(self._search_result_counts.values())
+        counts = list(self.mail_stats._search_result_counts.values())
         if len(counts) == 0:
             result = 0
         else:

--- a/tac/agents/v1/mail.py
+++ b/tac/agents/v1/mail.py
@@ -21,16 +21,18 @@
 """
 This module contains the classes required for message management.
 
+- MailStats: The MailStats class tracks statistics on messages processed by MailBox.
 - MailBox: The MailBox enqueues incoming messages, searches and errors from the OEF and sends outgoing messages to the OEF.
 - InBox: Temporarily stores messages for the agent.
 - OutBox: Temporarily stores and sends messages to the OEF and other agents.
 """
 
-import logging
 import asyncio
+import datetime
+import logging
 from queue import Queue, Empty
 from threading import Thread
-from typing import List, Optional, Any, Union
+from typing import List, Optional, Any, Union, Dict
 
 from oef.agents import OEFAgent
 from oef.messages import PROPOSE_TYPES, CFP_TYPES, CFP, Decline, Propose, Accept, Message as ByteMessage, \
@@ -46,6 +48,45 @@ OEFMessage = Union[SearchResult, OEFErrorMessage, DialogueErrorMessage]
 ControllerMessage = ByteMessage
 AgentMessage = Union[ByteMessage, CFP, Propose, Accept, Decline]
 Message = Union[OEFMessage, ControllerMessage, AgentMessage]
+
+
+class MailStats(object):
+    """The MailStats class tracks statistics on messages processed by MailBox."""
+
+    def __init__(self) -> None:
+        """
+        Instantiate mail stats.
+
+        :return: None
+        """
+        self._search_start_time = {}  # type: Dict[int, datetime.datetime]
+        self._search_timedelta = {}  # type: Dict[int, datetime.timedelta]
+        self._search_result_counts = {}  # type: Dict[int, int]
+
+    def search_start(self, search_id: int) -> None:
+        """
+        Add a search id and start time.
+
+        :param search_id: the search id
+
+        :return: None
+        """
+        assert search_id not in self._search_start_time
+        self._search_start_time[search_id] = datetime.datetime.now()
+
+    def search_end(self, search_id: int, nb_search_results: int) -> None:
+        """
+        Add end time for a search id.
+
+        :param search_id: the search id
+        :param nb_search_results: the number of agents returned in the search result
+
+        :return: None
+        """
+        assert search_id in self._search_start_time
+        assert search_id not in self._search_timedelta
+        self._search_timedelta[search_id] = (datetime.datetime.now() - self._search_start_time[search_id]).total_seconds() * 1000
+        self._search_result_counts[search_id] = nb_search_results
 
 
 class MailBox(OEFAgent):
@@ -66,6 +107,12 @@ class MailBox(OEFAgent):
         self.in_queue = Queue()
         self.out_queue = Queue()
         self._mail_box_thread = None  # type: Optional[Thread]
+        self._mail_stats = MailStats()
+
+    @property
+    def mail_stats(self) -> MailStats:
+        """Get the mail stats."""
+        return self._mail_stats
 
     def on_message(self, msg_id: int, dialogue_id: int, origin: str, content: bytes) -> None:
         """
@@ -89,6 +136,7 @@ class MailBox(OEFAgent):
 
         :return: None
         """
+        self.mail_stats.search_end(search_id, len(agents))
         self.in_queue.put(SearchResult(search_id, agents))
 
     def on_oef_error(self, answer_id: int, operation: OEFErrorOperation) -> None:
@@ -254,6 +302,7 @@ class OutBox(object):
                 self.mail_box.unregister_service(out.message_id, out.service_description)
             elif isinstance(out, OutContainer) and out.query is not None:
                 logger.debug("Outgoing query: search_id={}".format(out.search_id))
+                self.mail_box.mail_stats.search_start(out.search_id)
                 self.mail_box.search_services(out.search_id, out.query)
             elif isinstance(out, CFP):
                 logger.debug("Outgoing cfp: msg_id={}, dialogue_id={}, origin={}, target={}, query={}".format(out.msg_id, out.dialogue_id, out.destination, out.target, out.query))


### PR DESCRIPTION
This PR:
- creates a new class MailStats connected to MailBox.
- moves the search stats to MailStats

This addresses the removal of the artificial time lack introduced into search stats by the queueing of messages in mailbox.