### PR TITLE
Make the agent loop until a controller is found

### DIFF
--- a/tac/agents/v1/base/participant_agent.py
+++ b/tac/agents/v1/base/participant_agent.py
@@ -75,7 +75,6 @@ class ParticipantAgent(Agent):
         self.in_box = InBox(self.mail_box)
         self.out_box = OutBox(self.mail_box)
 
-        self._is_competing = False  # type: bool
         self._game_instance = GameInstance(name, strategy, self.mail_box.mail_stats, services_interval, pending_transaction_timeout, dashboard)  # type: Optional[GameInstance]
         self.max_reactions = max_reactions
 
@@ -88,20 +87,14 @@ class ParticipantAgent(Agent):
         """Get the game instance."""
         return self._game_instance
 
-    @property
-    def is_competing(self) -> bool:
-        """Check if the agent is competing."""
-        return self._is_competing
-
     def act(self) -> None:
         """
         Perform the agent's actions.
 
         :return: None
         """
-        if not self.is_competing:
+        if self.game_instance.game_phase == GamePhase.PRE_GAME:
             self.oef_handler.search_for_tac()
-            self._is_competing = True
         if self.game_instance.game_phase == GamePhase.GAME:
             if self.game_instance.is_time_to_update_services():
                 self.oef_handler.update_services()

--- a/tac/agents/v1/base/reactions.py
+++ b/tac/agents/v1/base/reactions.py
@@ -263,10 +263,13 @@ class OEFReactions(OEFSearchReactionInterface):
 
         :return: None
         """
+        if self.game_instance.game_phase != GamePhase.PRE_GAME:
+            logger.debug("[{}]: Ignoring controller search result, the agent is already competing.".format(self.agent_name))
+            return
+
         if len(agent_pbks) == 0:
             logger.debug("[{}]: Couldn't find the TAC controller. Retrying...".format(self.agent_name))
             time.sleep(3.0)
-            self._search_for_tac()
         elif len(agent_pbks) > 1:
             logger.error("[{}]: Found more than one TAC controller. Stopping...".format(self.agent_name))
             self.liveness._is_stopped = True
@@ -334,19 +337,6 @@ class OEFReactions(OEFSearchReactionInterface):
         msg = GetStateUpdate(self.crypto.public_key, self.crypto).serialize()
         self.out_box.out_queue.put(OutContainer(message=msg, message_id=0, dialogue_id=0, destination=controller_pbk))
 
-    def _search_for_tac(self) -> None:
-        """
-        Search for active TAC Controller.
-
-        We assume that the controller is registered as a service with the 'tac' data model
-        and with an attribute version = 1.
-
-        :return: None
-        """
-        query = Query([Constraint("version", GtEq(1))])
-        search_id = self.game_instance.search.get_next_id()
-        self.game_instance.search.ids_for_tac.add(search_id)
-        self.out_box.out_queue.put(OutContainer(query=query, search_id=search_id))
 
 class DialogueReactions(DialogueReactionInterface):
     """The DialogueReactions class defines the reactions of an agent in the context of a Dialogue."""

--- a/tac/agents/v1/base/reactions.py
+++ b/tac/agents/v1/base/reactions.py
@@ -269,7 +269,6 @@ class OEFReactions(OEFSearchReactionInterface):
 
         if len(agent_pbks) == 0:
             logger.debug("[{}]: Couldn't find the TAC controller. Retrying...".format(self.agent_name))
-            time.sleep(3.0)
         elif len(agent_pbks) > 1:
             logger.error("[{}]: Found more than one TAC controller. Stopping...".format(self.agent_name))
             self.liveness._is_stopped = True

--- a/tac/agents/v1/base/reactions.py
+++ b/tac/agents/v1/base/reactions.py
@@ -27,22 +27,20 @@ This module contains the classes which define the reactions of an agent.
 """
 
 import logging
-import time
 from typing import List, Union
 
 from oef.messages import CFP, Propose, Accept, Decline, Message as ByteMessage, SearchResult, OEFErrorMessage, \
     DialogueErrorMessage
-from oef.query import Query, Constraint, GtEq
 from oef.utils import Context
 
 from tac.agents.v1.agent import Liveness
 from tac.agents.v1.base.dialogues import Dialogue
-from tac.agents.v1.base.helpers import dialogue_label_from_transaction_id
 from tac.agents.v1.base.game_instance import GameInstance, GamePhase
-from tac.agents.v1.base.stats_manager import EndState
+from tac.agents.v1.base.helpers import dialogue_label_from_transaction_id
 from tac.agents.v1.base.interfaces import ControllerReactionInterface, OEFSearchReactionInterface, \
     DialogueReactionInterface
 from tac.agents.v1.base.negotiation_behaviours import FIPABehaviour
+from tac.agents.v1.base.stats_manager import EndState
 from tac.agents.v1.mail import OutBox, OutContainer
 from tac.helpers.crypto import Crypto
 from tac.helpers.misc import TAC_SUPPLY_DATAMODEL_NAME


### PR DESCRIPTION
This PR proposes a change in the behaviour of a participant agent during the setup of a game.

Specifically, the change regards the case when the agent receives the result from a search for controllers.
If no agent has been found, instead of stopping, the agent sleep for 3 seconds and sends again the same search request.

Notably, a special case is when there is no controller registered on the OEF. The agent just keeps looping, sending the same request again and again, hoping for a controller agent to be found.