### PR TITLE
Fix terminate method of ControllerAgent.

### DIFF
--- a/tac/platform/controller.py
+++ b/tac/platform/controller.py
@@ -713,9 +713,10 @@ class ControllerAgent(OEFAgent):
             self._is_running = False
             self.game_handler.notify_tac_cancelled()
             self._loop.call_soon_threadsafe(self.stop)
-            if self.monitor.is_running: self.monitor.stop()
             self._message_processing_task.join()
             self._message_processing_task = None
+            if self.monitor.is_running:
+                self.monitor.stop()
 
     def check_inactivity_timeout(self, rate: Optional[float] = 2.0) -> None:
         """


### PR DESCRIPTION
Fix an issue in `ControllerAgent.terminate` method due to multithreading. Before stopping the dashboard, wait that all the incoming messages have been processed and that the message processing thread has stopped.

Otherwise, it might happen that some message handler wants to update the dashboard when it has already been stopped.

The following is an example of exception thrown due to the mentioned issue:
```
[2019-07-04 14:39:44,559][tac.platform.controller][dispatch][ERROR] 'NoneType' object has no attribute 'update'
Traceback (most recent call last):
  File "/home/marcofavorito/fetchai/agents-tac/tac/platform/controller.py", line 456, in dispatch
    return handle_request(request)
  File "/home/marcofavorito/fetchai/agents-tac/tac/platform/controller.py", line 215, in __call__
    return self.handle(request)
  File "/home/marcofavorito/fetchai/agents-tac/tac/platform/controller.py", line 326, in handle
    self._handle_valid_transaction(request)
  File "/home/marcofavorito/fetchai/agents-tac/tac/platform/controller.py", line 350, in _handle_valid_transaction
    self.controller_agent.monitor.update()
  File "/home/marcofavorito/fetchai/agents-tac/tac/gui/monitor.py", line 99, in update
    self.dashboard.update()
AttributeError: 'NoneType' object has no attribute 'update'
```