### PR TITLE
Adds callbacks for error handling to controller agent.

### DIFF
--- a/tac/agents/v1/base/reactions.py
+++ b/tac/agents/v1/base/reactions.py
@@ -239,7 +239,7 @@ class OEFReactions(OEFSearchReactionInterface):
 
         :return: None
         """
-        logger.debug("[{}]: Received OEF error: answer_id={}, operation={}"
+        logger.error("[{}]: Received OEF error: answer_id={}, operation={}"
                      .format(self.agent_name, oef_error.msg_id, oef_error.oef_error_operation))
 
     def on_dialogue_error(self, dialogue_error: DialogueErrorMessage) -> None:
@@ -250,7 +250,7 @@ class OEFReactions(OEFSearchReactionInterface):
 
         :return: None
         """
-        logger.debug("[{}]: Received Dialogue error: answer_id={}, dialogue_id={}, origin={}"
+        logger.error("[{}]: Received Dialogue error: answer_id={}, dialogue_id={}, origin={}"
                      .format(self.agent_name, dialogue_error.msg_id, dialogue_error.dialogue_id, dialogue_error.origin))
 
     def _on_controller_search_result(self, agent_pbks: List[str]) -> None:

--- a/tac/platform/controller.py
+++ b/tac/platform/controller.py
@@ -683,7 +683,7 @@ class ControllerAgent(OEFAgent):
 
         :return: None
         """
-        logger.debug("[{}]: Received OEF error: answer_id={}, operation={}"
+        logger.error("[{}]: Received OEF error: answer_id={}, operation={}"
                      .format(self.name, answer_id, operation))
 
     def on_dialogue_error(self, answer_id: int, dialogue_id: int, origin: str) -> None:
@@ -696,7 +696,7 @@ class ControllerAgent(OEFAgent):
 
         :return: None
         """
-        logger.debug("[{}]: Received Dialogue error: answer_id={}, dialogue_id={}, origin={}"
+        logger.error("[{}]: Received Dialogue error: answer_id={}, dialogue_id={}, origin={}"
                      .format(self.name, answer_id, dialogue_id, origin))
 
     def register(self):

--- a/tac/platform/controller.py
+++ b/tac/platform/controller.py
@@ -45,6 +45,7 @@ from typing import Optional, Set
 
 import dateutil
 from oef.agents import OEFAgent
+from oef.messages import Message as OEFErrorOperation
 from oef.schema import Description, DataModel, AttributeSchema
 
 from tac.gui.monitor import Monitor, NullMonitor, VisdomMonitor
@@ -672,6 +673,31 @@ class ControllerAgent(OEFAgent):
         response = self.dispatcher.process_request(content, origin)  # type: Optional[Response]
         if response is not None:
             self.send_message(msg_id, dialogue_id, origin, response.serialize())
+
+    def on_oef_error(self, answer_id: int, operation: OEFErrorOperation) -> None:
+        """
+        Handle an oef error.
+
+        :param answer_id: the answer id
+        :param operation: the oef operation
+
+        :return: None
+        """
+        logger.debug("[{}]: Received OEF error: answer_id={}, operation={}"
+                     .format(self.name, answer_id, operation))
+
+    def on_dialogue_error(self, answer_id: int, dialogue_id: int, origin: str) -> None:
+        """
+        Handle a dialogue error.
+
+        :param answer_id: the answer id
+        :param dialogue_id: the dialogue id
+        :param origin: the public key of the sending agent
+
+        :return: None
+        """
+        logger.debug("[{}]: Received Dialogue error: answer_id={}, dialogue_id={}, origin={}"
+                     .format(self.name, answer_id, dialogue_id, origin))
 
     def register(self):
         """


### PR DESCRIPTION
## Proposed changes

This adds error handling callbacks `on_oef_error` and `on_dialogue_error` to the controller agent.

## Fixes

It fixes #275 

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

na
