### PR TITLE
fix how in simulation script the CLI  arguments are forwarded.

### DIFF
--- a/simulation/v1/tac_agent_spawner.py
+++ b/simulation/v1/tac_agent_spawner.py
@@ -143,7 +143,7 @@ def spawn_baseline_agents(arguments) -> List[multiprocessing.Process]:
     nb_baseline_agents_world_modeling = round(arguments.nb_baseline_agents * fraction_world_modeling)
 
     threads = [multiprocessing.Process(target=run_baseline_agent, kwargs=dict(
-        name=_make_id(i, i < nb_baseline_agents_world_modeling, arguments.nb_agents),
+        name=_make_id(i, i < nb_baseline_agents_world_modeling, arguments.nb_baseline_agents),
         oef_addr=arguments.oef_addr,
         oef_port=arguments.oef_port,
         register_as=arguments.register_as,
@@ -153,7 +153,7 @@ def spawn_baseline_agents(arguments) -> List[multiprocessing.Process]:
         pending_transaction_timeout=arguments.pending_transaction_timeout,
         gui=arguments.gui,
         visdom_addr=arguments.visdom_addr,
-        visdom_port=arguments.visdom_port)) for i in range(arguments.nb_agents)]
+        visdom_port=arguments.visdom_port)) for i in range(arguments.nb_baseline_agents)]
 
     def signal_handler(sig, frame):
         """Filter the SIGINT from the parent process."""


### PR DESCRIPTION
When instantiating baseline agents, the `nb_agents` is used, rather than `nb_baseline_agents`

## Proposed changes

N/A

## Fixes

N/A

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
