### PR TITLE
remove redundant call to 'notify_tac_cancelled'.

### DIFF
--- a/tac/platform/controller.py
+++ b/tac/platform/controller.py
@@ -602,7 +602,6 @@ class GameHandler:
         else:
             logger.debug("[{}]: Not enough agents to start TAC. Registered agents: {}, minimum number of agents: {}."
                          .format(self.controller_agent.name, nb_reg_agents, min_nb_agents))
-            self.notify_tac_cancelled()
             self.controller_agent.terminate()
             return False
 


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

When there are not enough agents to start a TAC, there is a redundant call to `notify_tac_cancelled()`, which caused the controller agent to send the `Cancelled` message twice.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.