### PR TITLE
remove '--skip-lock' flag when building virtualenv in Dockerfile.

### DIFF
--- a/docker-tac-develop/Dockerfile
+++ b/docker-tac-develop/Dockerfile
@@ -58,7 +58,7 @@ COPY . /build
 RUN sudo make clean
 
 RUN pipenv --python python3.7
-RUN pipenv install --dev --skip-lock
+RUN pipenv install --dev 
 RUN pipenv run pip3 install .
 
 ENTRYPOINT []


### PR DESCRIPTION
## Proposed changes

When building the TAC development Docker image, the `Pipfile.lock` wasn't used due to
the '--skip-lock' flag. Removing it forces the installation of the right dependencies.

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.
