### PR TITLE
add 'update' method in main loop for generic internal operations.

### DIFF
--- a/tac/agents/v1/agent.py
+++ b/tac/agents/v1/agent.py
@@ -138,7 +138,7 @@ class Agent:
 
     @abstractmethod
     def update(self) -> None:
-        """Update the current state of the agent
+        """Update the current state of the agent.
 
         :return None
         """

--- a/tac/agents/v1/agent.py
+++ b/tac/agents/v1/agent.py
@@ -105,6 +105,7 @@ class Agent:
             self.act()
             time.sleep(self._timeout)
             self.react()
+            self.update()
 
         self.stop()
         logger.debug("[{}]: Exiting main loop...".format(self.name))
@@ -133,4 +134,11 @@ class Agent:
         React to incoming events.
 
         :return: None
+        """
+
+    @abstractmethod
+    def update(self) -> None:
+        """Update the current state of the agent
+
+        :return None
         """

--- a/tac/agents/v1/base/game_instance.py
+++ b/tac/agents/v1/base/game_instance.py
@@ -117,7 +117,6 @@ class GameInstance:
         self.goods_demanded_description = None
 
         self.transaction_manager = TransactionManager(agent_name, pending_transaction_timeout=pending_transaction_timeout)
-        self.transaction_manager.start()
 
         self.stats_manager = StatsManager(mail_stats, dashboard)
 
@@ -255,12 +254,12 @@ class GameInstance:
 
         if not state_after_locks.check_transaction_is_consistent(transaction, self.game_configuration.tx_fee):
             message = "[{}]: the proposed transaction is not consistent with the state after locks.".format(self.agent_name)
-            return [False, message]
+            return False, message
         proposal_delta_score = state_after_locks.get_score_diff_from_transaction(transaction, self.game_configuration.tx_fee)
 
         result = self.strategy.is_acceptable_proposal(proposal_delta_score)
         message = "[{}]: is good proposal for {}? {}: tx_id={}, delta_score={}, amount={}".format(self.agent_name, dialogue.role, result, transaction.transaction_id, proposal_delta_score, transaction.amount)
-        return [result, message]
+        return result, message
 
     def get_service_description(self, is_supply: bool) -> Description:
         """
@@ -362,13 +361,13 @@ class GameInstance:
         state_after_locks = self._agent_state.apply(transactions, self.game_configuration.tx_fee)
         return state_after_locks
 
-    def generate_proposal(self, cfp_services: Dict[str, Union[bool, List]], is_seller: bool) -> List[Description]:
+    def generate_proposal(self, cfp_services: Dict[str, Union[bool, List]], is_seller: bool) -> Optional[List[Description]]:
         """
         Wrap the function which generates proposals from a seller or buyer.
 
         If there are locks as seller, it applies them.
 
-        :param query: the query associated with the cfp.
+        :param cfp_services: the query associated with the cfp.
         :param is_seller: Boolean indicating the role of the agent.
 
         :return: a list of descriptions
@@ -380,12 +379,11 @@ class GameInstance:
             if not self.is_matching(cfp_services, proposal): continue
             if not proposal.values["price"] > 0: continue
             proposals.append(proposal)
-        if proposals == []:
+        if not proposals:
             return None
         else:
             return random.choice(proposals)
 
     def stop(self):
         """Stop the services attached to the game instance."""
-        self.transaction_manager.stop()
         self.stats_manager.stop()

--- a/tac/agents/v1/base/game_instance.py
+++ b/tac/agents/v1/base/game_instance.py
@@ -308,8 +308,8 @@ class GameInstance:
         """
         Check for a match between the CFP services and the goods description.
 
-        :param cfp_services: a dictionary with the cfp services
-        :param goods_description: a description of the goods
+        :param cfp_services: the services associated with the cfp.
+        :param goods_description: a description of the goods.
 
         :return: Bool
         """

--- a/tac/agents/v1/base/participant_agent.py
+++ b/tac/agents/v1/base/participant_agent.py
@@ -126,6 +126,14 @@ class ParticipantAgent(Agent):
 
         self.out_box.send_nowait()
 
+    def update(self) -> None:
+        """
+        Update the state of the agent.
+
+        :return: None
+        """
+        self.game_instance.transaction_manager.cleanup_pending_transactions()
+
     def stop(self) -> None:
         """
         Stop the agent.

--- a/tac/agents/v1/base/transaction_manager.py
+++ b/tac/agents/v1/base/transaction_manager.py
@@ -22,9 +22,7 @@
 
 import datetime
 import logging
-import time
 from collections import defaultdict, deque
-from threading import Thread
 from typing import Dict, Tuple, Deque
 
 from tac.agents.v1.base.dialogues import DialogueLabel


### PR DESCRIPTION
## Proposed changes

The PR proposes a new abstract method in the `Agent` class, the `update()` method. This method is called at every iteration of the main loop of the agent (that is, the one in the method `run_main_loop()`). The purpose of the `update()` method is to handle generic operations to update the state of the agent. 

Notice how it differs from the `act()` method, that handles the outputs of the agent, and the `react()` method, that handles the inputs of the agent.
Moreover, it's worth noticing that, at the moment, this is just a logical separation of operations, rather than an increase in expressiveness. There's no practical difference between the `react` and the `update` method.

## Fixes

This PR is somehow related to #295. That's because some operations that we used to accomplish by allocating threads now can be completed inside this method.

Among other changes, the PR brings also small fixes to the source code.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

- It could be possible to generalize this method by including a `task_queue` that consumes small tasks, so instead of requiring the programmer to implement the `update()` method, he could just enqueue some tasks in the `task_queue`, delegating its execution to the framework. That implies the need for defining the right abstractions, error handling etc.
- Another remark is that, while before this change the cleanup job of the `TransactionManager` run every `_cleanup_locked_transactions_task_timeout` seconds, now it runs at the same rate of the main loop. That might not be the desired behaviour. The replication of the same behaviour requires some efforts to the developer. So it's worth thinking about a way to make his life easier.
