### PR TITLE
Add 'setup' and 'teardown' method.

### DIFF
--- a/docs/sections/baseline_agent.rst
+++ b/docs/sections/baseline_agent.rst
@@ -9,9 +9,14 @@ In this section, we describe the baseline agent v1 :class:`~tac.agents.v1.exampl
 Main Loop and Event Loop
 ------------------------
 
-A generic :class:`~tac.agents.v1.agent.Agent` can be started via :meth:`~tac.agents.v1.agent.Agent.start`. This starts the :class:`~tac.agents.v1.mail.MailBox` and a main loop implemented in :meth:`~tac.agents.v1.agent.Agent.run_main_loop`.
+A generic :class:`~tac.agents.v1.agent.Agent` can be started via :meth:`~tac.agents.v1.agent.Agent.start`. This starts the :class:`~tac.agents.v1.mail.MailBox` and a main loop implemented in :meth:`~tac.agents.v1.agent.Agent._run_main_loop`.
 
 The mailbox is responsible for handling incoming and outgoing messages. The :class:`~tac.agents.v1.mail.InBox` enqueues incoming messages on an :attr:`~tac.agents.v1.mail.MailBox.in_queue` for later processing, the :class:`~tac.agents.v1.mail.OutBox` picks messages from the :attr:`~tac.agents.v1.mail.MailBox.out_queue` and sends them to the OEF.
+
+Before the execution of the main loop, the framework will call the user's implementation of the
+:meth:`~tac.agents.v1.agent.Agent.setup` method, to let the initialization of the resources needed to the agent.
+Upon exit, the framework will call the user's implementation of the
+:meth:`~tac.agents.v1.agent.Agent.teardown` method, to let the release of the initialized resources.
 
 The main loop deals with processing enqueued events/messages. It has the methods :meth:`~tac.agents.v1.agent.Agent.act` and :meth:`~tac.agents.v1.agent.Agent.react` which handle the active and reactive agent behaviours.
 

--- a/tac/agents/v1/agent.py
+++ b/tac/agents/v1/agent.py
@@ -100,12 +100,18 @@ class Agent:
 
         :return: None
         """
+        logger.debug("[{}]: Calling setup method...".format(self.name))
+        self.setup()
+
         logger.debug("[{}]: Start processing messages...".format(self.name))
         while not self.liveness.is_stopped:
             self.act()
             time.sleep(self._timeout)
             self.react()
             self.update()
+
+        logger.debug("[{}]: Calling teardown method...".format(self.name))
+        self.teardown()
 
         self.stop()
         logger.debug("[{}]: Exiting main loop...".format(self.name))
@@ -119,6 +125,14 @@ class Agent:
         logger.debug("[{}]: Stopping message processing...".format(self.name))
         self.liveness._is_stopped = True
         self.mail_box.stop()
+
+    @abstractmethod
+    def setup(self) -> None:
+        """
+        Set up the agent.
+
+        :return: None
+        """
 
     @abstractmethod
     def act(self) -> None:
@@ -141,4 +155,12 @@ class Agent:
         """Update the current state of the agent.
 
         :return None
+        """
+
+    @abstractmethod
+    def teardown(self) -> None:
+        """
+        Tear down the agent.
+
+        :return: None
         """

--- a/tac/agents/v1/base/participant_agent.py
+++ b/tac/agents/v1/base/participant_agent.py
@@ -163,3 +163,9 @@ class ParticipantAgent(Agent):
         logger.debug("Trying to rejoin in 5 seconds...")
         time.sleep(5.0)
         self.start(rejoin=True)
+
+    def setup(self) -> None:
+        """Set up the agent."""
+
+    def teardown(self) -> None:
+        """Tear down the agent."""


### PR DESCRIPTION
## Proposed changes

Add a `setup()` and `teardown()` method to the `Agent` class.

## Fixes

Fixes #332 

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

The `setup()` method is called in the `_run_main_loop()` function, before the `while` loop.
The `teardown()` method, on the other hand, is called after the same `while` loop, just before the call to the `stop()` method.