### PR TITLE
Make possible the instantiation of an agent without the OEF running.

### DIFF
--- a/tac/agents/v1/agent.py
+++ b/tac/agents/v1/agent.py
@@ -57,7 +57,12 @@ class Liveness:
 class Agent:
     """This class implements a template agent."""
 
-    def __init__(self, name: str, oef_addr: str, oef_port: int = 10000, private_key_pem_path: Optional[str] = None, timeout: Optional[float] = 1.0) -> None:
+    def __init__(self, name: str,
+                 oef_addr: str,
+                 oef_port: int = 10000,
+                 private_key_pem_path: Optional[str] = None,
+                 timeout: Optional[float] = 1.0,
+                 debug: bool = False) -> None:
         """
         Instantiate the agent.
 
@@ -66,6 +71,7 @@ class Agent:
         :param oef_port: TCP/IP port of the OEF Agent
         :param private_key_pem_path: the path to the private key of the agent.
         :param timeout: the time in (fractions of) seconds to time out an agent between act and react
+        :param debug: if True, run the agent in debug mode.
 
         :return: None
         """
@@ -73,6 +79,8 @@ class Agent:
         self._crypto = Crypto(private_key_pem_path=private_key_pem_path)
         self._liveness = Liveness()
         self._timeout = timeout
+
+        self.debug = debug
 
         self.mail_box = None  # type: Optional[MailBox]
         self.in_box = None  # type: Optional[InBox]
@@ -121,7 +129,9 @@ class Agent:
 
         :return: None
         """
-        self.mail_box.start()
+        if not self.debug:
+            self.mail_box.start()
+
         self.liveness._is_stopped = False
         self._run_main_loop()
 

--- a/tac/agents/v1/base/participant_agent.py
+++ b/tac/agents/v1/base/participant_agent.py
@@ -55,7 +55,8 @@ class ParticipantAgent(Agent):
                  services_interval: int = 10,
                  pending_transaction_timeout: int = 30,
                  dashboard: Optional[AgentDashboard] = None,
-                 private_key_pem: Optional[str] = None):
+                 private_key_pem: Optional[str] = None,
+                 debug: bool = False):
         """
         Initialize a participant agent.
 
@@ -69,8 +70,9 @@ class ParticipantAgent(Agent):
         :param pending_transaction_timeout: the timeout for cleanup of pending negotiations and unconfirmed transactions.
         :param dashboard: a Visdom dashboard to visualize agent statistics during the competition.
         :param private_key_pem: the path to a private key in PEM format.
+        :param debug: if True, run the agent in debug mode.
         """
-        super().__init__(name, oef_addr, oef_port, private_key_pem, agent_timeout)
+        super().__init__(name, oef_addr, oef_port, private_key_pem, agent_timeout, debug=debug)
         self.mail_box = FIPAMailBox(self.crypto.public_key, oef_addr, oef_port)
         self.in_box = InBox(self.mail_box)
         self.out_box = OutBox(self.mail_box)

--- a/tac/agents/v1/mail.py
+++ b/tac/agents/v1/mail.py
@@ -100,13 +100,14 @@ class MailStats(object):
 class MailBox(OEFAgent):
     """The MailBox enqueues incoming messages, searches and errors from the OEF and sends outgoing messages to the OEF."""
 
-    def __init__(self, public_key: str, oef_addr: str, oef_port: int = 10000) -> None:
+    def __init__(self, public_key: str, oef_addr: str, oef_port: int = 10000, debug: bool = False) -> None:
         """
         Instantiate the mailbox.
 
         :param public_key: the public key of the agent
         :param oef_addr: TCP/IP address of the OEF Agent
         :param oef_port: TCP/IP port of the OEF Agent
+        :param debug: start the mailbox in debug mode.
 
         :return: None
         """
@@ -115,6 +116,8 @@ class MailBox(OEFAgent):
         self.out_queue = Queue()
         self._mail_box_thread = None  # type: Optional[Thread]
         self._mail_stats = MailStats()
+
+        self.debug = debug
 
     @property
     def mail_stats(self) -> MailStats:
@@ -323,6 +326,11 @@ class OutBox(object):
         logger.debug("Checking for message or search query on out queue...")
         while not self.out_queue.empty():
             out = self.out_queue.get_nowait()
+
+            if self.mail_box.debug:
+                logger.warning("Dropping message of type '{}' from the out queue...".format(type(out.message)))
+                continue
+
             if isinstance(out, OutContainer) and out.message is not None:
                 logger.debug("Outgoing message type: type={}".format(type(out.message)))
                 self.mail_box.send_message(out.message_id, out.dialogue_id, out.destination, out.message)

--- a/tac/agents/v1/mail.py
+++ b/tac/agents/v1/mail.py
@@ -111,7 +111,6 @@ class MailBox(OEFAgent):
         :return: None
         """
         super().__init__(public_key, oef_addr, oef_port, loop=asyncio.new_event_loop())
-        self.connect()
         self.in_queue = Queue()
         self.out_queue = Queue()
         self._mail_box_thread = None  # type: Optional[Thread]
@@ -204,6 +203,7 @@ class MailBox(OEFAgent):
 
         :return: None
         """
+        self.connect()
         self._mail_box_thread = Thread(target=super().run)
         self._mail_box_thread.start()
 
@@ -358,7 +358,7 @@ class OutBox(object):
 class FIPAMailBox(MailBox):
     """The FIPAMailBox enqueues additionally FIPA specific messages."""
 
-    def __init__(self, public_key: str, oef_addr: str, oef_port: int = 10000) -> None:
+    def __init__(self, public_key: str, oef_addr: str, oef_port: int = 10000, **kwargs) -> None:
         """
         Instantiate the FIPAMailBox.
 
@@ -368,7 +368,7 @@ class FIPAMailBox(MailBox):
 
         :return: None
         """
-        super().__init__(public_key, oef_addr, oef_port)
+        super().__init__(public_key, oef_addr, oef_port, **kwargs)
 
     def on_cfp(self, msg_id: int, dialogue_id: int, origin: str, target: int, query: CFP_TYPES) -> None:
         """

--- a/tests/test_agent/test_agent_state.py
+++ b/tests/test_agent/test_agent_state.py
@@ -54,8 +54,8 @@ def test_agent_initiated():
 def test_agent_connected(network_node):
     """Test that when the agent is connected, her state is AgentState.CONNECTED."""
     test_agent = TestAgent()
+    test_agent.mail_box.connect()
     assert test_agent.agent_state == AgentState.CONNECTED
-    test_agent.stop()
 
 
 def test_agent_running(network_node):

--- a/tests/test_agent/test_misc.py
+++ b/tests/test_agent/test_misc.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2018-2019 Fetch.AI Limited
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Test miscellaneous features for the agent module."""
+import time
+from threading import Thread
+
+import pytest
+
+from tac.agents.v1.agent import Agent
+
+from tac.agents.v1.base.participant_agent import ParticipantAgent
+from tac.agents.v1.examples.strategy import BaselineStrategy
+from tac.agents.v1.mail import FIPAMailBox
+
+
+class TestAgent(Agent):
+    """A class to implement an agent for testing."""
+
+    def __init__(self, **kwargs):
+        """Initialize the test agent."""
+        super().__init__("test_agent", "127.0.0.1", 10000, **kwargs)
+        self.mail_box = FIPAMailBox(self.crypto.public_key, "127.0.0.1", 10000)
+
+    def act(self) -> None:
+        """Perform actions."""
+
+    def react(self) -> None:
+        """React to incoming events."""
+
+    def update(self) -> None:
+        """Update the current state of the agent."""
+
+
+def test_debug_flag_true():
+    """
+    Test that the debug mode works correctly.
+
+    That is, an agent can be initialized without the OEF running.
+    """
+    test_agent = TestAgent(debug=True)
+    job = Thread(target=test_agent.start)
+    job.start()
+    time.sleep(1.0)
+    test_agent.stop()
+    job.join()


### PR DESCRIPTION
## Proposed changes

- Introduce the flag `connect_soon` to the `MailBox` constructor, such that it's possible to postpone the connection of the mailbox when the `start` method is called.
- Add the flag `connect_soon` to the `ParticipantAgent` constructor and forward it to the mailbox constructor.
- Add tests for the new feature.

## Fixes

Fixes #330.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

None.