### PR TITLE
Update setup.py and refactor dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ tac/gui/.visdom_env/
 
 sandbox/TAC
 sandbox/data
+simulation/v1/data/
 
 *.pem
 !tests/data/priv.pem`

--- a/Pipfile
+++ b/Pipfile
@@ -36,6 +36,7 @@ sphinx = "*"
 wtforms = "*"
 visdom = "*"
 aea = {editable = true,git = "https://github.com/fetchai/agents-aea.git",ref = "develop"}
+colorlog = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "331da37d0749378faeded473e56279f8164d9c5e73a1fe0b233e656952e89eeb"
+            "sha256": "c104a4860ddd2511c5a6510c10724b3bff7c843eb3e5b1c664919525c497e3f4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -131,6 +131,14 @@
             ],
             "version": "==7.0"
         },
+        "colorlog": {
+            "hashes": [
+                "sha256:3cf31b25cbc8f86ec01fef582ef3b840950dea414084ed19ab922c8b493f9b42",
+                "sha256:450f52ea2a2b6ebb308f034ea9a9b15cea51e65650593dca1da3eb792e4e4981"
+            ],
+            "index": "pypi",
+            "version": "==4.0.2"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c",
@@ -191,7 +199,7 @@
         },
         "fetchai-ledger-api": {
             "git": "https://github.com/fetchai/ledger-api-py.git",
-            "ref": "a5f513a9247524ee767e1dd1519aad1a1f4383e3"
+            "ref": "514e17c209932357d000be599e85362a1cbeb8a0"
         },
         "flask": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -30,63 +30,6 @@ from setuptools import setup, find_packages, Command
 
 PACKAGE_NAME = "tac"
 
-
-class protoc(Command):
-    """A custom command to generate Python Protobuf modules from oef-core-protocol"""
-
-    description = "Generate Python Protobuf modules from protobuf files specifications."
-    user_options = [
-        ("proto-path", None, "Path to the `oef-core-protocol` folder.")
-    ]
-
-    def run(self):
-        command = self._build_command()
-        self._run_command(command)
-        self._fix_import_statements_in_all_protobuf_modules()
-
-    def _run_command(self, command):
-        self.announce("Running %s" % str(command))
-        subprocess.check_call(command)
-
-    def initialize_options(self):
-        """Set default values for options."""
-        self.proto_path = os.path.join("proto")
-
-    def finalize_options(self):
-        """Post-process options."""
-        assert os.path.exists(self.proto_path), ('Directory %s does not exist.' % self.proto_path)
-
-    def _find_protoc_executable_path(self):
-        result = shutil.which("protoc")
-
-        if result is None or result == "":
-            raise EnvironmentError("protoc compiler not found.")
-        return result
-
-    def _build_command(self):
-        protoc_executable_path = self._find_protoc_executable_path()
-        command = [protoc_executable_path] + self._get_arguments()
-        return command
-
-    def _get_arguments(self):
-        arguments = []
-        arguments.append("--proto_path=%s" % self.proto_path)
-        arguments.append("--python_out=tac")
-        arguments += glob.glob(os.path.join(self.proto_path, "*.proto"))
-        return arguments
-
-    def _fix_import_statements_in_all_protobuf_modules(self):
-        generated_protobuf_python_modules = glob.glob(os.path.join("tac", "*_pb2.py"))
-        for filepath in generated_protobuf_python_modules:
-            self._fix_import_statements_in_protobuf_module(filepath)
-
-    def _fix_import_statements_in_protobuf_module(self, filename):
-        for line in fileinput.input(filename, inplace=True):
-            line = re.sub("^(import \w*_pb2)", "from . \g<1>", line)
-            # stdout redirected to the file (fileinput.input with inplace=True)
-            sys.stdout.write(line)
-
-
 here = os.path.abspath(os.path.dirname(__file__))
 about = {}
 with open(os.path.join(here, PACKAGE_NAME, '__version__.py'), 'r') as f:
@@ -112,9 +55,6 @@ setup(
     url=about['__url__'],
     long_description=readme,
     packages=find_packages(include=["tac*"]),
-    cmdclass={
-        'protoc': protoc,
-    },
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,14 @@ with open('README.md', 'r') as f:
     readme = f.read()
 
 
+extras = {
+    "gui": [
+        "flask",
+        "flask_restful",
+        "wtforms"
+    ]
+}
+
 setup(
     name=about['__title__'],
     description=about['__description__'],
@@ -116,19 +124,14 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     install_requires=[
+        "aea @ git+https://github.com/fetchai/agents-aea.git@develop#egg=aea",
         "oef",
         "numpy",
-        "matplotlib",
-        "flask",
-        "flask_restful",
-        "wtforms",
         "python-dateutil",
-        "visdom",
-        "cryptography",
-        "fetchai-ledger-api @ git+https://github.com/fetchai/ledger-api-py.git#egg=fetchai-ledger-api",
-        "base58"
+        "visdom"
     ],
     tests_require=["tox"],
+    extras_require=extras,
     zip_safe=False,
     include_package_data=True,
     data_files=[

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     install_requires=[
         "aea @ git+https://github.com/fetchai/agents-aea.git@develop#egg=aea",
         "oef",
+        "colorlog",  # TODO 'oef' dependency, to be fixed.
         "numpy",
         "python-dateutil",
         "visdom"

--- a/tac/agents/controller/agent.py
+++ b/tac/agents/controller/agent.py
@@ -29,7 +29,7 @@ import random
 import time
 from typing import Union, Optional
 
-import dateutil
+import dateutil.parser
 from aea.agent import Agent
 from aea.channel.oef import OEFMailBox
 from aea.mail.base import Envelope
@@ -123,12 +123,10 @@ class ControllerAgent(Agent):
             if inactivity_duration > self.game_handler.tac_parameters.inactivity_timedelta:
                 logger.debug("[{}]: Inactivity timeout expired. Terminating...".format(self.name))
                 self.stop()
-                self.teardown()
                 return
             elif current_time > self.game_handler.tac_parameters.end_time:
                 logger.debug("[{}]: Competition timeout expired. Terminating...".format(self.name))
                 self.stop()
-                self.teardown()
                 return
 
     def react(self) -> None:

--- a/tac/platform/game/stats.py
+++ b/tac/platform/game/stats.py
@@ -23,15 +23,9 @@
 from typing import Any, Dict, Optional, Tuple, List
 
 import numpy as np
-import matplotlib
-import os
-import pylab as plt
 
-from aea.crypto.base import Crypto
 from tac.agents.controller.base.states import Game
 from tac.agents.participant.v1.base.states import AgentState
-
-matplotlib.use('agg')
 
 
 class GameStats:
@@ -50,7 +44,7 @@ class GameStats:
     @classmethod
     def from_json(cls, d: Dict[str, Any]):
         """Read from json."""
-        game = Game.from_dict(d, Crypto())  # any crypto object will do here
+        game = Game.from_dict(d)
         return GameStats(game)
 
     def holdings_history(self):
@@ -145,29 +139,6 @@ class GameStats:
             result[idx + 1, :] = np.asarray(temp_game.get_prices(), dtype=np.float32)
 
         return result
-
-    def plot_score_history(self, output_path: Optional[str] = None) -> None:
-        """
-        Plot the history of the scores, for every agent, by transaction.
-
-        :param output_path: an optional output path where to save the figure generated.
-
-        :return: None
-        """
-        keys, history = self.score_history()
-
-        plt.clf()
-        plt.plot(history)
-        plt.legend([self.game.configuration.agent_pbk_to_name[agent_pbk] for agent_pbk in keys], loc="best")
-        plt.xlabel("Transactions")
-        plt.ylabel("Score")
-
-        plt.gca().xaxis.set_major_locator(plt.MaxNLocator(integer=True))
-
-        if output_path is None:
-            plt.show()
-        else:
-            plt.savefig(output_path)
 
     def eq_vs_mean_price(self) -> Tuple[List[str], np.ndarray]:
         """
@@ -285,15 +256,3 @@ class GameStats:
         result = np.transpose(result)
 
         return keys, result
-
-    def dump(self, directory: str, experiment_name: str) -> None:
-        """
-        Dump the plot.
-
-        :param directory: the directory where experiments details are listed.
-        :param experiment_name: the name of the folder where the data about experiment will be saved.
-
-        :return: None.
-        """
-        experiment_dir = directory + "/" + experiment_name
-        self.plot_score_history(os.path.join(experiment_dir, "plot.png"))


### PR DESCRIPTION
## Proposed changes

This PR updates the project dependencies, removing obsolete dependencies or splitting them by functionality using the `setuptools` extras mechanism. It also removes an obsolete build subcommand.

More in detail:
- `base58` has been removed, since it is only used in `aea`.
- `matplotlib` was not useful anymore, used only in an obsolete function of the `GameStats` class.
- `fetchai-ledger-api` was not used.
- the dependencies `flask` and related have been packed into the `"gui"` extension. So if the user would like to use the `tac.gui` code, it should install the package with a command like:
```
pip install tac[gui]
```
Or, if installing from source:
```
pip install .[gui]
```

## Fixes

None.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.