### PR TITLE
Add default TAC version to agent templates main scripts

### DIFF
--- a/tac/gui/launcher/api/resources/reporting_agent.py
+++ b/tac/gui/launcher/api/resources/reporting_agent.py
@@ -96,7 +96,10 @@ def parse_arguments():
         help="Path to a file containing a private key in PEM format.",
     )
     parser.add_argument(
-        "--expected-version-id", type=str, help="The expected version id of the TAC."
+        "--expected-version-id",
+        type=str,
+        help="The expected version id of the TAC.",
+        default="tac_v1",
     )
     parser.add_argument(
         "--rejoin",

--- a/templates/v1/advanced.py
+++ b/templates/v1/advanced.py
@@ -92,7 +92,10 @@ def parse_arguments():
         help="Path to a file containing a private key in PEM format.",
     )
     parser.add_argument(
-        "--expected-version-id", type=str, help="The epected version id of the TAC."
+        "--expected-version-id",
+        type=str,
+        help="The expected version id of the TAC.",
+        default="tac_v1",
     )
     parser.add_argument(
         "--rejoin",

--- a/templates/v1/basic.py
+++ b/templates/v1/basic.py
@@ -93,7 +93,10 @@ def parse_arguments():
         help="Path to a file containing a private key in PEM format.",
     )
     parser.add_argument(
-        "--expected-version-id", type=str, help="The expected version id of the TAC."
+        "--expected-version-id",
+        type=str,
+        help="The expected version id of the TAC.",
+        default="tac_v1",
     )
     parser.add_argument(
         "--rejoin",

--- a/templates/v1/expert.py
+++ b/templates/v1/expert.py
@@ -54,7 +54,10 @@ def parse_arguments():
         help="Path to a file containing a private key in PEM format.",
     )
     parser.add_argument(
-        "--expected-version-id", type=str, help="The epected version id of the TAC."
+        "--expected-version-id",
+        type=str,
+        help="The epected version id of the TAC.",
+        default="tac_v1",
     )
 
     return parser.parse_args()


### PR DESCRIPTION
## Proposed changes

Add default TAC version to agent templates main scripts. It defaulted to `None` causing troubles in the serialization of the constraint `GtEq`

## Fixes

Fix https://github.com/fetchai/agents-tac/issues/389

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
